### PR TITLE
feat: add root Dockerfile for .NET API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+WORKDIR /app
+EXPOSE 8080
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY ["dotnet-server/dotnet-server.csproj", "dotnet-server/"]
+RUN dotnet restore "dotnet-server/dotnet-server.csproj"
+COPY . .
+WORKDIR /src/dotnet-server
+RUN dotnet build "dotnet-server.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "dotnet-server.csproj" -c Release -o /app/publish /p:UseAppHost=false
+
+FROM base AS final
+WORKDIR /app
+
+# Install PostgreSQL client tools
+RUN apt-get update && apt-get install -y postgresql-client && rm -rf /var/lib/apt/lists/*
+
+COPY --from=publish /app/publish .
+
+# Create non-root user
+RUN adduser --disabled-password --gecos '' appuser && chown -R appuser /app
+USER appuser
+
+# Configure for production
+ENV ASPNETCORE_ENVIRONMENT=Production
+ENV ASPNETCORE_URLS=http://+:8080
+
+ENTRYPOINT ["dotnet", "dotnet-server.dll"]


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile at repository root for dotnet-server API

## Testing
- `dotnet build dotnet-server/dotnet-server.csproj -c Release -o /tmp/build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e1fec4d4832289c176c40d4e7d95