### PR TITLE
Default Postgres port when parsing URL connection string

### DIFF
--- a/dotnet-server/Program.cs
+++ b/dotnet-server/Program.cs
@@ -12,7 +12,14 @@ using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
 using System.Linq; // for result.Errors.Select(...)
 
+using DotNetEnv;
 
+
+var envPath = Path.Combine(Directory.GetCurrentDirectory(), "..", ".env");
+if (File.Exists(envPath))
+{
+    Env.Load(envPath);
+}
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -94,8 +101,9 @@ public static class ProgramExtensions
             {
                 var uri = new Uri(connectionString);
                 var userInfo = uri.UserInfo.Split(':', 2);
+                var port = uri.Port > 0 ? uri.Port : 5432;
                 connectionString =
-                    $"Host={uri.Host};Port={uri.Port};Database={uri.LocalPath.TrimStart('/')};" +
+                    $"Host={uri.Host};Port={port};Database={uri.LocalPath.TrimStart('/')};" +
                     $"Username={userInfo[0]};Password={userInfo.ElementAtOrDefault(1)};" +
                     "Pooling=true;SSL Mode=Require;Trust Server Certificate=true";
             }

--- a/dotnet-server/dotnet-server.csproj
+++ b/dotnet-server/dotnet-server.csproj
@@ -7,8 +7,8 @@
     <RootNamespace>dotnet_server</RootNamespace>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="FirebaseAdmin" Version="3.1.0" />
+    <ItemGroup>
+      <PackageReference Include="FirebaseAdmin" Version="3.1.0" />
     <PackageReference Include="Google.Cloud.Storage.V1" Version="4.11.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.3" />
@@ -26,10 +26,11 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.6.1" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.2" />
-    <PackageReference Include="Resend" Version="0.0.13" />
-    <PackageReference Include="Square" Version="42.0.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.1" />
-  </ItemGroup>
+      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.2" />
+      <PackageReference Include="Resend" Version="0.0.13" />
+      <PackageReference Include="Square" Version="42.0.1" />
+      <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.1" />
+      <PackageReference Include="DotNetEnv" Version="3.0.0" />
+    </ItemGroup>
 
-</Project>
+  </Project>


### PR DESCRIPTION
## Summary
- default PostgreSQL URL connection strings to port 5432 when no port is specified
- load environment variables from the repository's root `.env` file before building configuration

## Testing
- `dotnet build dotnet-server -c Debug` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68c1eaacdd988322b8b2b6e8ee262e52