### PR TITLE
Expand consultation status options

### DIFF
--- a/dotnet-server/Migrations/20250813003755_UpdateConsultationStatusConstraint.Designer.cs
+++ b/dotnet-server/Migrations/20250813003755_UpdateConsultationStatusConstraint.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DotNet.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace dotnet_server.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250813003755_UpdateConsultationStatusConstraint")]
+    partial class UpdateConsultationStatusConstraint
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -261,9 +264,7 @@ namespace dotnet_server.Migrations
 
                     b.ToTable("Consultations", t =>
                         {
-                            t.HasCheckConstraint(
-                                "CK_Consultations_Status",
-                                "\"Status\" IN ('draft', 'awaiting-review', 'submitted-to-square', 'approved', 'rejected')");
+                            t.HasCheckConstraint("CK_Consultations_Status", "\"Status\" IN ('draft', 'awaiting-review', 'submitted-to-square', 'approved', 'rejected')");
                         });
                 });
 

--- a/dotnet-server/Migrations/20250813003755_UpdateConsultationStatusConstraint.cs
+++ b/dotnet-server/Migrations/20250813003755_UpdateConsultationStatusConstraint.cs
@@ -1,0 +1,36 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace dotnet_server.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdateConsultationStatusConstraint : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_Consultations_Status",
+                table: "Consultations");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "CK_Consultations_Status",
+                table: "Consultations",
+                sql: "\"Status\" IN ('draft', 'awaiting-review', 'submitted-to-square', 'approved', 'rejected')");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_Consultations_Status",
+                table: "Consultations");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "CK_Consultations_Status",
+                table: "Consultations",
+                sql: "\"Status\" IN ('pending', 'approved', 'rejected')");
+        }
+    }
+}

--- a/dotnet-server/_Data/ApplicationDbContext.cs
+++ b/dotnet-server/_Data/ApplicationDbContext.cs
@@ -99,7 +99,9 @@ namespace DotNet.Data
                 .HasCheckConstraint("CK_Users_UserRole", "\"UserRole\" IN ('artist', 'client')");
                 
             builder.Entity<Consultation>()
-                .HasCheckConstraint("CK_Consultations_Status", "\"Status\" IN ('pending', 'approved', 'rejected')");
+                .HasCheckConstraint(
+                    "CK_Consultations_Status",
+                    "\"Status\" IN ('draft', 'awaiting-review', 'submitted-to-square', 'approved', 'rejected')");
                 
             builder.Entity<TattooJob>()
                 .HasCheckConstraint("CK_TattooJobs_Type", "\"Type\" IN ('client_request', 'artist_offer')");


### PR DESCRIPTION
## Summary
- allow consultation status to include draft, awaiting-review, submitted-to-square, approved, and rejected
- add migration updating check constraint

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1fa2e8cc0832285edcc28b3b5b05f