### PR TITLE
fix: use valid initial consultation status

### DIFF
--- a/dotnet-server/_Services/ConsultationService.cs
+++ b/dotnet-server/_Services/ConsultationService.cs
@@ -221,7 +221,7 @@ When all are collected, confirm the summary and say:
                     Id = Guid.NewGuid(),
                     ClientId = userId ?? string.Empty, // allow anonymous
                     ArtistId = resolvedArtistId, // <-- set it HERE
-                    Status = "started",
+                    Status = "draft",
                     SubmittedAt = DateTime.UtcNow,
                     ChatHistory = "[]" // 🚑 ensure we don't deserialize null
                 };


### PR DESCRIPTION
## Summary
- use `draft` as the initial consultation status so it passes the `CK_Consultations_Status` constraint

## Testing
- `dotnet build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c1fba5410c83228de1a413f1738471