### PR TITLE
Support external clients and messaging integration

### DIFF
--- a/dotnet-server/Program.cs
+++ b/dotnet-server/Program.cs
@@ -35,6 +35,7 @@ builder.Services.Configure<SquareOptions>(builder.Configuration.GetSection("Squa
 builder.Services.AddSingleton<ISquareAppointmentsService, SquareAppointmentsService>();
 builder.Services.AddScoped<IConsultationService, ConsultationService>();
 builder.Services.AddScoped<IStorageService, AzureBlobStorageService>();
+builder.Services.AddScoped<IMessagingIntegrationService, MessagingIntegrationService>();
 builder.Services.AddControllers()
     .AddJsonOptions(opts => opts.JsonSerializerOptions.PropertyNameCaseInsensitive = true);
 

--- a/dotnet-server/_Data/ApplicationDbContext.cs
+++ b/dotnet-server/_Data/ApplicationDbContext.cs
@@ -18,6 +18,7 @@ namespace DotNet.Data
         public DbSet<TattooJob> TattooJobs { get; set; }
         public DbSet<Appointment> Appointments { get; set; }
         public DbSet<UserImage> UserImages { get; set; }
+        public DbSet<ClientProfile> ClientProfiles { get; set; }
         
         protected override void OnModelCreating(ModelBuilder builder)
         {
@@ -49,6 +50,12 @@ namespace DotNet.Data
                 .HasOne(c => c.Client)
                 .WithMany(u => u.ClientConsultations)
                 .HasForeignKey(c => c.ClientId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            builder.Entity<Consultation>()
+                .HasOne(c => c.ClientProfile)
+                .WithMany()
+                .HasForeignKey(c => c.ClientProfileId)
                 .OnDelete(DeleteBehavior.Restrict);
                 
             builder.Entity<Consultation>()

--- a/dotnet-server/_Models/ClientProfile.cs
+++ b/dotnet-server/_Models/ClientProfile.cs
@@ -1,0 +1,20 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace DotNet.Models
+{
+    public class ClientProfile
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public Guid Id { get; set; }
+
+        [Required]
+        public string FullName { get; set; } = string.Empty;
+
+        public string? Email { get; set; }
+
+        public string? PhoneNumber { get; set; }
+    }
+}

--- a/dotnet-server/_Models/Consultation.cs
+++ b/dotnet-server/_Models/Consultation.cs
@@ -13,8 +13,12 @@ namespace DotNet.Models
         public Guid Id { get; set; }
 
         [ForeignKey("Client")]
-        public string ClientId { get; set; } = string.Empty;
-        public virtual ApplicationUser Client { get; set; } = null!;
+        public string? ClientId { get; set; }
+        public virtual ApplicationUser? Client { get; set; } = null!;
+
+        [ForeignKey("ClientProfile")]
+        public Guid? ClientProfileId { get; set; }
+        public virtual ClientProfile? ClientProfile { get; set; }
 
 
         [ForeignKey("Artist")]

--- a/dotnet-server/_Services/IConsultationService.cs
+++ b/dotnet-server/_Services/IConsultationService.cs
@@ -9,10 +9,15 @@ namespace DotNet.Services
     public interface IConsultationService
     {
         Task<Guid> StartConsultationAsync(string userId, string artistId, string? squareArtistId);
+        Task<Guid> StartExternalConsultationAsync(Guid clientProfileId, string artistId, string? squareArtistId);
         Task<string> SendMessageAsync(Guid consultationId, string userId, string message);
+        Task<string> SendExternalMessageAsync(Guid consultationId, Guid clientProfileId, string message);
         Task<string> SendMessageWithImageAsync(Guid consultationId, string userId, string message, IFormFile image);
+        Task<string> SendExternalMessageWithImageAsync(Guid consultationId, Guid clientProfileId, string message, IFormFile image);
         Task<ConsultationDto> GetConsultationAsync(Guid consultationId, string userId);
+        Task<ConsultationDto> GetExternalConsultationAsync(Guid consultationId, Guid clientProfileId);
         Task<List<ConsultationDto>> GetUserConsultationsAsync(string userId);
+        Task<List<ConsultationDto>> GetExternalClientConsultationsAsync(Guid clientProfileId);
         Task<bool> UpdateConsultationStatusAsync(Guid consultationId, string status, string userId);
         Task<string> SubmitToSquareAsync(Guid consultationId, string userId);
     }

--- a/dotnet-server/_Services/IMessagingIntegrationService.cs
+++ b/dotnet-server/_Services/IMessagingIntegrationService.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace DotNet.Services
+{
+    public interface IMessagingIntegrationService
+    {
+        Task ProcessIncomingMessageAsync(string platform, string artistId, string senderHandle, string message);
+    }
+}

--- a/dotnet-server/_Services/MessagingIntegrationService.cs
+++ b/dotnet-server/_Services/MessagingIntegrationService.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Threading.Tasks;
+using DotNet.Data;
+using DotNet.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace DotNet.Services
+{
+    public class MessagingIntegrationService : IMessagingIntegrationService
+    {
+        private readonly ApplicationDbContext _context;
+        private readonly IConsultationService _consultationService;
+        private readonly ILogger<MessagingIntegrationService> _logger;
+
+        public MessagingIntegrationService(ApplicationDbContext context, IConsultationService consultationService, ILogger<MessagingIntegrationService> logger)
+        {
+            _context = context;
+            _consultationService = consultationService;
+            _logger = logger;
+        }
+
+        public async Task ProcessIncomingMessageAsync(string platform, string artistId, string senderHandle, string message)
+        {
+            // Lookup or create an external client based on the sender handle (phone, username, etc.)
+            var client = await _context.ClientProfiles.FirstOrDefaultAsync(c => c.PhoneNumber == senderHandle || c.Email == senderHandle);
+            if (client == null)
+            {
+                client = new ClientProfile
+                {
+                    FullName = senderHandle,
+                    PhoneNumber = senderHandle
+                };
+                _context.ClientProfiles.Add(client);
+                await _context.SaveChangesAsync();
+            }
+
+            // Find existing consultation or start a new one
+            var consultation = await _context.Consultations.FirstOrDefaultAsync(c => c.ClientProfileId == client.Id && c.ArtistId == artistId);
+            Guid consultationId;
+            if (consultation == null)
+            {
+                consultationId = await _consultationService.StartExternalConsultationAsync(client.Id, artistId, null);
+            }
+            else
+            {
+                consultationId = consultation.Id;
+            }
+
+            // Send message through consultation service to generate next response
+            var response = await _consultationService.SendExternalMessageAsync(consultationId, client.Id, message);
+
+            // TODO: Send 'response' back to the user via the appropriate platform API
+            _logger.LogInformation("{Platform} message processed for {Sender}: {Response}", platform, senderHandle, response);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `ClientProfile` model for non-login clients and link to consultations
- expand `ConsultationService` with validation and external-client workflows
- introduce `MessagingIntegrationService` and register it for social platform message handling

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ff536ae88322a031a87a37fd62da