### PR TITLE
fix: allow starting consultation without user account

### DIFF
--- a/dotnet-server/_Services/ConsultationService.cs
+++ b/dotnet-server/_Services/ConsultationService.cs
@@ -217,9 +217,12 @@ When all are collected, confirm the summary and say:
                 if (artistExists == null)
                     throw new ArgumentException("Artist not found");
 
-                var clientExists = await _userManager.FindByIdAsync(userId);
-                if (clientExists == null)
-                    throw new ArgumentException("Client not found");
+                if (!string.IsNullOrEmpty(userId))
+                {
+                    var clientExists = await _userManager.FindByIdAsync(userId);
+                    if (clientExists == null)
+                        throw new ArgumentException("Client not found");
+                }
 
                 var c = new Consultation
                 {


### PR DESCRIPTION
## Summary
- allow anonymous users to start a consultation without requiring a client account

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c201e873ec832293c49ae984e3fb58