### PR TITLE
Fix AddClientProfile migration metadata

### DIFF
--- a/dotnet-server/Migrations/20250910235000_AddClientProfile.cs
+++ b/dotnet-server/Migrations/20250910235000_AddClientProfile.cs
@@ -1,9 +1,13 @@
 using System;
+using DotNet.Data;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace dotnet_server.Migrations
 {
     /// <inheritdoc />
+    [DbContext(typeof(ApplicationDbContext))]
+    [Migration("20250910235000_AddClientProfile")]
     public partial class AddClientProfile : Migration
     {
         /// <inheritdoc />


### PR DESCRIPTION
## Summary
- ensure `AddClientProfile` migration is discovered by adding missing metadata attributes

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c20b4505fc8322af240c142bd6119d