### PR TITLE
feat: track tenant plan and trial period

### DIFF
--- a/angular-client/src/_services/tenant.service.ts
+++ b/angular-client/src/_services/tenant.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../environments/environment';
+
+export interface Tenant {
+  id: string;
+  name: string;
+  metaPageId?: string;
+  instagramAccountId?: string;
+  plan: string;
+  trialEndsAt?: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class TenantService {
+  private apiUrl = `${environment.apiUrl}/tenants`;
+
+  constructor(private http: HttpClient) {}
+
+  getTenants(): Observable<Tenant[]> {
+    return this.http.get<Tenant[]>(this.apiUrl);
+  }
+
+  connectTenant(data: any) {
+    return this.http.post(`${this.apiUrl}/connect`, data);
+  }
+}

--- a/angular-client/src/app/app.component.html
+++ b/angular-client/src/app/app.component.html
@@ -54,6 +54,11 @@
                                         class="text-gray-600 dark:text-gray-300 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors"
                                         >Chat</a
                                 >
+                                <a
+                                        routerLink="/connect"
+                                        class="text-gray-600 dark:text-gray-300 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors"
+                                        >Connect</a
+                                >
                         </nav>
 </div>
         </header>

--- a/angular-client/src/app/app.routes.ts
+++ b/angular-client/src/app/app.routes.ts
@@ -1,8 +1,10 @@
 import { Routes } from '@angular/router'
 import { ChatComponent } from './chat/chat.component'
+import { ConnectComponent } from './connect/connect.component'
 
 export const routes: Routes = [
   { path: 'chat', component: ChatComponent },
+  { path: 'connect', component: ConnectComponent },
   { path: '', redirectTo: 'chat', pathMatch: 'full' },
   { path: '**', redirectTo: 'chat' },
 ]

--- a/angular-client/src/app/connect/connect.component.css
+++ b/angular-client/src/app/connect/connect.component.css
@@ -1,0 +1,1 @@
+/* basic spacing */

--- a/angular-client/src/app/connect/connect.component.html
+++ b/angular-client/src/app/connect/connect.component.html
@@ -1,0 +1,26 @@
+<div class="space-y-6">
+  <form [formGroup]="form" (ngSubmit)="submit()" class="space-y-4 max-w-md">
+    <input formControlName="name" placeholder="Tenant name" class="w-full border p-2 rounded" />
+    <input formControlName="metaPageId" placeholder="Facebook Page ID" class="w-full border p-2 rounded" />
+    <input formControlName="pageAccessToken" placeholder="Page Access Token" class="w-full border p-2 rounded" />
+    <input formControlName="instagramAccountId" placeholder="Instagram Account ID" class="w-full border p-2 rounded" />
+    <input formControlName="instagramToken" placeholder="Instagram Token" class="w-full border p-2 rounded" />
+    <select formControlName="plan" class="w-full border p-2 rounded">
+      <option value="trial">Trial (1 week)</option>
+      <option value="basic">Basic - $50/week</option>
+      <option value="premium">Premium - $100/week + auto bookings</option>
+    </select>
+    <button type="submit" class="bg-emerald-600 text-white px-4 py-2 rounded">Connect</button>
+  </form>
+
+  <div>
+    <h2 class="text-lg font-semibold mb-2">Existing Tenants</h2>
+    <ul class="list-disc pl-5" *ngIf="tenants$ | async as tenants">
+      <li *ngFor="let t of tenants">
+        {{ t.name }} - Plan: {{ t.plan }}
+        <span *ngIf="t.trialEndsAt">(trial ends {{ t.trialEndsAt | date:'mediumDate' }})</span>
+        - FB: {{ t.metaPageId || 'n/a' }} - IG: {{ t.instagramAccountId || 'n/a' }}
+      </li>
+    </ul>
+  </div>
+</div>

--- a/angular-client/src/app/connect/connect.component.spec.ts
+++ b/angular-client/src/app/connect/connect.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+
+import { ConnectComponent } from './connect.component';
+
+describe('ConnectComponent', () => {
+  let component: ConnectComponent;
+  let fixture: ComponentFixture<ConnectComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ConnectComponent, HttpClientTestingModule]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ConnectComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/angular-client/src/app/connect/connect.component.ts
+++ b/angular-client/src/app/connect/connect.component.ts
@@ -1,0 +1,42 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder } from '@angular/forms';
+import { TenantService } from '../../_services/tenant.service';
+import { Observable } from 'rxjs';
+import { Tenant } from '../../_services/tenant.service';
+
+@Component({
+  selector: 'app-connect',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './connect.component.html',
+  styleUrls: ['./connect.component.css']
+})
+export class ConnectComponent {
+  tenants$!: Observable<Tenant[]>;
+  form = this.fb.group({
+    name: [''],
+    metaPageId: [''],
+    pageAccessToken: [''],
+    instagramAccountId: [''],
+    instagramToken: [''],
+    plan: ['trial']
+  });
+
+  constructor(private fb: FormBuilder, private tenantService: TenantService) {
+    this.loadTenants();
+  }
+
+  loadTenants() {
+    this.tenants$ = this.tenantService.getTenants();
+  }
+
+  submit() {
+    if (this.form.valid) {
+      this.tenantService.connectTenant(this.form.value).subscribe(() => {
+        this.form.reset();
+        this.loadTenants();
+      });
+    }
+  }
+}

--- a/dotnet-server/_Controllers/TenantController.cs
+++ b/dotnet-server/_Controllers/TenantController.cs
@@ -1,0 +1,110 @@
+using DotNet.Data;
+using DotNet.Models;
+using DotNet.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Linq;
+
+namespace DotNet.Controllers
+{
+    [ApiController]
+    [Route("api/tenants")]
+    public class TenantController : ControllerBase
+    {
+        private readonly ApplicationDbContext _db;
+        private readonly ITenantService _tenantService;
+
+        public TenantController(ApplicationDbContext db, ITenantService tenantService)
+        {
+            _db = db;
+            _tenantService = tenantService;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> GetAll()
+        {
+            var tenants = await _db.Tenants
+                .AsNoTracking()
+                .Select(t => new
+                {
+                    t.Id,
+                    t.Name,
+                    t.MetaPageId,
+                    t.InstagramAccountId,
+                    t.Plan,
+                    t.TrialEndsAt
+                })
+                .ToListAsync();
+            return Ok(tenants);
+        }
+
+        public class ConnectRequest
+        {
+            public string Name { get; set; } = string.Empty;
+            public string? MetaPageId { get; set; }
+            public string? PageAccessToken { get; set; }
+            public string? InstagramAccountId { get; set; }
+            public string? InstagramToken { get; set; }
+            public string? Plan { get; set; }
+            public DateTime? TrialEndsAt { get; set; }
+        }
+
+        [HttpPost("connect")]
+        public async Task<IActionResult> Connect([FromBody] ConnectRequest request)
+        {
+            if (string.IsNullOrWhiteSpace(request.Name))
+            {
+                return BadRequest(new { error = "Name is required" });
+            }
+
+            var tenant = await _db.Tenants
+                .FirstOrDefaultAsync(t => t.MetaPageId == request.MetaPageId);
+
+            var plan = string.IsNullOrWhiteSpace(request.Plan) ? "trial" : request.Plan;
+
+            if (tenant == null)
+            {
+                tenant = new Tenant
+                {
+                    Name = request.Name,
+                    MetaPageId = request.MetaPageId,
+                    InstagramAccountId = request.InstagramAccountId,
+                    EncryptedPageAccessToken = _tenantService.EncryptToken(request.PageAccessToken),
+                    EncryptedInstagramToken = _tenantService.EncryptToken(request.InstagramToken),
+                    Plan = plan,
+                    TrialEndsAt = request.TrialEndsAt
+                };
+                if (tenant.Plan == "trial" && tenant.TrialEndsAt == null)
+                {
+                    tenant.TrialEndsAt = DateTime.UtcNow.AddDays(7);
+                }
+                _db.Tenants.Add(tenant);
+            }
+            else
+            {
+                tenant.Name = request.Name;
+                tenant.MetaPageId = request.MetaPageId;
+                tenant.InstagramAccountId = request.InstagramAccountId;
+                tenant.EncryptedPageAccessToken = _tenantService.EncryptToken(request.PageAccessToken);
+                tenant.EncryptedInstagramToken = _tenantService.EncryptToken(request.InstagramToken);
+                if (!string.IsNullOrWhiteSpace(request.Plan))
+                {
+                    tenant.Plan = plan;
+                }
+                if (request.TrialEndsAt.HasValue)
+                {
+                    tenant.TrialEndsAt = request.TrialEndsAt;
+                }
+                if (tenant.Plan == "trial" && tenant.TrialEndsAt == null)
+                {
+                    tenant.TrialEndsAt = DateTime.UtcNow.AddDays(7);
+                }
+                _db.Tenants.Update(tenant);
+            }
+
+            await _db.SaveChangesAsync();
+            return Ok(new { tenant.Id });
+        }
+    }
+}

--- a/dotnet-server/_Models/Tenant.cs
+++ b/dotnet-server/_Models/Tenant.cs
@@ -36,5 +36,15 @@ namespace DotNet.Models
         /// Encrypted Instagram access token.
         /// </summary>
         public string? EncryptedInstagramToken { get; set; }
+
+        /// <summary>
+        /// Subscription plan for this tenant (trial, basic, premium).
+        /// </summary>
+        public string Plan { get; set; } = "trial";
+
+        /// <summary>
+        /// When the trial period ends, if applicable.
+        /// </summary>
+        public DateTime? TrialEndsAt { get; set; }
     }
 }

--- a/dotnet-server/_Services/ITenantService.cs
+++ b/dotnet-server/_Services/ITenantService.cs
@@ -16,5 +16,10 @@ namespace DotNet.Services
         /// Decrypt an access token stored for the tenant.
         /// </summary>
         string? DecryptToken(string? encryptedToken);
+
+        /// <summary>
+        /// Encrypt a token for storage.
+        /// </summary>
+        string? EncryptToken(string? token);
     }
 }

--- a/dotnet-server/_Services/TenantService.cs
+++ b/dotnet-server/_Services/TenantService.cs
@@ -42,5 +42,19 @@ namespace DotNet.Services
                 return null;
             }
         }
+
+        public string? EncryptToken(string? token)
+        {
+            if (string.IsNullOrEmpty(token)) return null;
+            try
+            {
+                return _protector.Protect(token);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to encrypt tenant token");
+                return null;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- store tenant subscription plan and optional trial end timestamp
- expose plan fields in API and select plan in Connect UI

## Testing
- `dotnet build` *(fails: command not found)*
- `npm test -- --watch=false` *(fails: Tailwind CSS PostCSS plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c4af30376483229b141f7790e9fdb3