### PR TITLE
Fix FormBuilder initialization order in ConnectComponent

### DIFF
--- a/angular-client/src/app/connect/connect.component.ts
+++ b/angular-client/src/app/connect/connect.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ReactiveFormsModule, FormBuilder } from '@angular/forms';
+import { ReactiveFormsModule, FormBuilder, FormGroup } from '@angular/forms';
 import { TenantService } from '../../_services/tenant.service';
 import { Observable } from 'rxjs';
 import { Tenant } from '../../_services/tenant.service';
@@ -14,16 +14,17 @@ import { Tenant } from '../../_services/tenant.service';
 })
 export class ConnectComponent {
   tenants$!: Observable<Tenant[]>;
-  form = this.fb.group({
-    name: [''],
-    metaPageId: [''],
-    pageAccessToken: [''],
-    instagramAccountId: [''],
-    instagramToken: [''],
-    plan: ['trial']
-  });
+  form: FormGroup;
 
   constructor(private fb: FormBuilder, private tenantService: TenantService) {
+    this.form = this.fb.group({
+      name: [''],
+      metaPageId: [''],
+      pageAccessToken: [''],
+      instagramAccountId: [''],
+      instagramToken: [''],
+      plan: ['trial']
+    });
     this.loadTenants();
   }
 


### PR DESCRIPTION
## Summary
- avoid using `FormBuilder` before Angular injects it by moving form creation into the constructor
- type the form as `FormGroup`

## Testing
- `npm test` *(fails: requires @tailwindcss/postcss configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c4b8808e1c8322b25c4eb98cafcf68