### PR TITLE
Make meta verify token configurable

### DIFF
--- a/dotnet-server/_Controllers/MetaWebhookController.cs
+++ b/dotnet-server/_Controllers/MetaWebhookController.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using DotNet.Models;
 using DotNet.Services;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
 
 namespace DotNet.Controllers
 {
@@ -12,12 +13,16 @@ namespace DotNet.Controllers
     {
         private readonly TattooController _chatController;
         private readonly ITenantService _tenantService;
-        private readonly string _verifyToken = "tattoo-verify-prod";
+        private readonly string _verifyToken;
 
-        public MetaWebhookController(TattooController chatController, ITenantService tenantService)
+        public MetaWebhookController(
+            TattooController chatController,
+            ITenantService tenantService,
+            IConfiguration configuration)
         {
             _chatController = chatController;
             _tenantService = tenantService;
+            _verifyToken = configuration["MetaVerifyToken"] ?? "tattoo-verify-prod";
         }
 
         [HttpGet]
@@ -26,7 +31,7 @@ namespace DotNet.Controllers
             [FromQuery(Name = "hub.challenge")] string challenge,
             [FromQuery(Name = "hub.verify_token")] string verifyToken)
         {
-            return (mode == "subscribe" && verifyToken == _verifyToken)
+            return (string.Equals(mode, "subscribe", StringComparison.OrdinalIgnoreCase) && verifyToken == _verifyToken)
                 ? Content(challenge)
                 : Unauthorized();
         }


### PR DESCRIPTION
## Summary
- allow Meta webhook verify token to be configured via `MetaVerifyToken` environment variable
- handle webhook `hub.mode` comparison case-insensitively

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4becf5e088322ac8c6e7e9946b6ac