### PR TITLE
Add landing page with pricing tiers

### DIFF
--- a/angular-client/src/app/app.component.html
+++ b/angular-client/src/app/app.component.html
@@ -50,6 +50,11 @@
 
                         <nav class="flex items-center space-x-4">
                                 <a
+                                        routerLink="/"
+                                        class="text-gray-600 dark:text-gray-300 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors"
+                                        >Home</a
+                                >
+                                <a
                                         routerLink="/chat"
                                         class="text-gray-600 dark:text-gray-300 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors"
                                         >Chat</a

--- a/angular-client/src/app/app.routes.ts
+++ b/angular-client/src/app/app.routes.ts
@@ -1,10 +1,11 @@
 import { Routes } from '@angular/router'
 import { ChatComponent } from './chat/chat.component'
 import { ConnectComponent } from './connect/connect.component'
+import { LandingComponent } from './landing/landing.component'
 
 export const routes: Routes = [
+  { path: '', component: LandingComponent },
   { path: 'chat', component: ChatComponent },
   { path: 'connect', component: ConnectComponent },
-  { path: '', redirectTo: 'chat', pathMatch: 'full' },
-  { path: '**', redirectTo: 'chat' },
+  { path: '**', redirectTo: '' },
 ]

--- a/angular-client/src/app/landing/landing.component.css
+++ b/angular-client/src/app/landing/landing.component.css
@@ -1,0 +1,1 @@
+/* Tailwind handles styling; file exists for consistency */

--- a/angular-client/src/app/landing/landing.component.html
+++ b/angular-client/src/app/landing/landing.component.html
@@ -1,0 +1,35 @@
+<section class="text-center py-20">
+  <h2 class="text-4xl font-bold mb-4 text-emerald-600">Grow your tattoo business with AI</h2>
+  <p class="text-lg text-gray-600 dark:text-gray-300 max-w-2xl mx-auto">
+    Ever lose clients because you're so busy? Our assistant responds to DMs and books appointments so you never miss an opportunity.
+  </p>
+</section>
+
+<section class="py-12">
+  <h3 class="text-3xl font-semibold text-center mb-8">Plans</h3>
+  <div class="grid gap-6 md:grid-cols-3">
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6 flex flex-col">
+      <h4 class="text-xl font-bold mb-4">7-Day Free Trial</h4>
+      <p class="text-gray-600 dark:text-gray-300 flex-grow">Try the assistant free for a week.</p>
+      <div class="mt-6">
+        <span class="text-3xl font-bold">Free</span>
+      </div>
+    </div>
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6 flex flex-col">
+      <h4 class="text-xl font-bold mb-4">DM Assistant</h4>
+      <p class="text-gray-600 dark:text-gray-300 flex-grow">AI responds to your DMs.</p>
+      <div class="mt-6">
+        <span class="text-3xl font-bold">$50</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400">/week</span>
+      </div>
+    </div>
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6 flex flex-col">
+      <h4 class="text-xl font-bold mb-4">Booking Assistant</h4>
+      <p class="text-gray-600 dark:text-gray-300 flex-grow">AI responds to DMs and auto-books with card capture.</p>
+      <div class="mt-6">
+        <span class="text-3xl font-bold">$100</span>
+        <span class="text-sm text-gray-600 dark:text-gray-400">/week</span>
+      </div>
+    </div>
+  </div>
+</section>

--- a/angular-client/src/app/landing/landing.component.ts
+++ b/angular-client/src/app/landing/landing.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-landing',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './landing.component.html',
+  styleUrls: ['./landing.component.css']
+})
+export class LandingComponent {}


### PR DESCRIPTION
## Summary
- Add Tailwind-styled landing page describing AI tattoo assistant benefits and pricing tiers.
- Route root path to new landing page and link it in navigation.

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Error: It looks like you're trying to use `tailwindcss` directly as a PostCSS plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68c5863c9d40832281c703969926d53d