### PR TITLE
Add Vercel config for Angular client

### DIFF
--- a/angular-client/README.md
+++ b/angular-client/README.md
@@ -57,3 +57,17 @@ Angular CLI does not come with an end-to-end testing framework by default. You c
 ## Additional Resources
 
 For more information on using the Angular CLI, including detailed command references, visit the [Angular CLI Overview and Command Reference](https://angular.dev/tools/cli) page.
+
+## Deploying to Vercel
+
+This project includes a `vercel.json` configuration so Vercel knows how to build and serve the Angular app.
+
+To deploy:
+
+1. Install the [Vercel CLI](https://vercel.com/docs/cli).
+2. From this `angular-client` directory, run:
+   ```bash
+   vercel --prod
+   ```
+3. Vercel will run `npm run build` and serve the contents of `dist/angular-client/browser`.
+

--- a/angular-client/vercel.json
+++ b/angular-client/vercel.json
@@ -1,0 +1,4 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist/angular-client/browser"
+}


### PR DESCRIPTION
## Summary
- add `vercel.json` so Vercel knows how to build and serve the Angular app
- document Vercel deployment steps in Angular README

## Testing
- `npm test` *(fails: It looks like you're trying to use `tailwindcss` directly as a PostCSS plugin...)*

------
https://chatgpt.com/codex/tasks/task_e_68c5891e1f588322875629b6034805ee