### PR TITLE
Refactor consultation messaging and Meta integration

### DIFF
--- a/dotnet-server/Migrations/20251001000000_ConsultationMessagesRefactor.cs
+++ b/dotnet-server/Migrations/20251001000000_ConsultationMessagesRefactor.cs
@@ -1,0 +1,132 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DotNet.Migrations
+{
+    public partial class ConsultationMessagesRefactor : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "CurrentStep",
+                table: "Consultations",
+                type: "text",
+                nullable: false,
+                defaultValue: "subject");
+
+            migrationBuilder.AddColumn<string>(
+                name: "SquareSyncError",
+                table: "Consultations",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "ArtistUserId",
+                table: "Tenants",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ExternalHandle",
+                table: "ClientProfiles",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "ConsultationMessages",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    ConsultationId = table.Column<Guid>(type: "uuid", nullable: false),
+                    OrderIndex = table.Column<int>(type: "integer", nullable: false),
+                    Role = table.Column<string>(type: "text", nullable: false),
+                    Content = table.Column<string>(type: "text", nullable: false),
+                    ImageUrl = table.Column<string>(type: "text", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ConsultationMessages", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ConsultationMessages_Consultations_ConsultationId",
+                        column: x => x.ConsultationId,
+                        principalTable: "Consultations",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ConsultationMessages_ConsultationId_OrderIndex",
+                table: "ConsultationMessages",
+                columns: new[] { "ConsultationId", "OrderIndex" },
+                unique: true);
+
+            migrationBuilder.Sql(@"
+                INSERT INTO \"ConsultationMessages\" (\"Id\", \"ConsultationId\", \"OrderIndex\", \"Role\", \"Content\", \"ImageUrl\", \"CreatedAt\")
+                SELECT md5(random()::text || clock_timestamp()::text)::uuid,
+                       c.\"Id\",
+                       elem.ordinality - 1,
+                       elem.value->>'role',
+                       elem.value->>'content',
+                       elem.value->>'image_url',
+                       c.\"SubmittedAt\"
+                FROM \"Consultations\" c
+                CROSS JOIN LATERAL jsonb_array_elements(
+                    CASE
+                        WHEN NULLIF(trim(c.\"ChatHistory\"), '') IS NULL THEN '[]'::jsonb
+                        ELSE c.\"ChatHistory\"::jsonb
+                    END
+                ) WITH ORDINALITY AS elem(value, ordinality);
+            ");
+
+            migrationBuilder.DropColumn(
+                name: "ChatHistory",
+                table: "Consultations");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ChatHistory",
+                table: "Consultations",
+                type: "text",
+                nullable: false,
+                defaultValue: "[]");
+
+            migrationBuilder.Sql(@"
+                UPDATE \"Consultations\" c
+                SET \"ChatHistory\" = COALESCE((
+                    SELECT jsonb_agg(jsonb_build_object(
+                        'role', m.\"Role\",
+                        'content', m.\"Content\",
+                        'image_url', m.\"ImageUrl\"
+                    ) ORDER BY m.\"OrderIndex\")
+                    FROM \"ConsultationMessages\" m
+                    WHERE m.\"ConsultationId\" = c.\"Id\"
+                ), '[]'::jsonb)::text;
+            ");
+
+            migrationBuilder.DropTable(
+                name: "ConsultationMessages");
+
+            migrationBuilder.DropColumn(
+                name: "CurrentStep",
+                table: "Consultations");
+
+            migrationBuilder.DropColumn(
+                name: "SquareSyncError",
+                table: "Consultations");
+
+            migrationBuilder.DropColumn(
+                name: "ArtistUserId",
+                table: "Tenants");
+
+            migrationBuilder.DropColumn(
+                name: "ExternalHandle",
+                table: "ClientProfiles");
+        }
+    }
+}

--- a/dotnet-server/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/dotnet-server/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -191,6 +191,9 @@ namespace dotnet_server.Migrations
                     b.Property<string>("Email")
                         .HasColumnType("text");
 
+                    b.Property<string>("ExternalHandle")
+                        .HasColumnType("text");
+
                     b.Property<string>("FullName")
                         .IsRequired()
                         .HasColumnType("text");
@@ -224,15 +227,15 @@ namespace dotnet_server.Migrations
                         .IsRequired()
                         .HasColumnType("text");
 
-                    b.Property<string>("ChatHistory")
-                        .IsRequired()
-                        .HasColumnType("text");
-
                     b.Property<string>("ClientId")
                         .HasColumnType("text");
 
                     b.Property<Guid?>("ClientProfileId")
                         .HasColumnType("uuid");
+
+                    b.Property<string>("CurrentStep")
+                        .IsRequired()
+                        .HasColumnType("text");
 
                     b.Property<string>("ContactFullName")
                         .IsRequired()
@@ -259,6 +262,10 @@ namespace dotnet_server.Migrations
                         .HasColumnType("text");
 
                     b.Property<string>("SquareCustomerId")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("SquareSyncError")
                         .IsRequired()
                         .HasColumnType("text");
 
@@ -289,6 +296,40 @@ namespace dotnet_server.Migrations
                                 "CK_Consultations_Status",
                                 "\"Status\" IN ('draft', 'awaiting-review', 'submitted-to-square', 'approved', 'rejected')");
                         });
+                });
+
+            modelBuilder.Entity("DotNet.Models.ConsultationMessage", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("ConsultationId")
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("Content")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("ImageUrl")
+                        .HasColumnType("text");
+
+                    b.Property<int>("OrderIndex")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("Role")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("ConsultationId", "OrderIndex")
+                        .IsUnique();
+
+                    b.ToTable("ConsultationMessages");
                 });
 
             modelBuilder.Entity("DotNet.Models.TattooJob", b =>
@@ -350,6 +391,9 @@ namespace dotnet_server.Migrations
                         .HasColumnType("text");
 
                     b.Property<string>("EncryptedPageAccessToken")
+                        .HasColumnType("text");
+
+                    b.Property<string>("ArtistUserId")
                         .HasColumnType("text");
 
                     b.Property<string>("InstagramAccountId")
@@ -620,6 +664,17 @@ namespace dotnet_server.Migrations
                     b.Navigation("ClientProfile");
                 });
 
+            modelBuilder.Entity("DotNet.Models.ConsultationMessage", b =>
+                {
+                    b.HasOne("DotNet.Models.Consultation", "Consultation")
+                        .WithMany("Messages")
+                        .HasForeignKey("ConsultationId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Consultation");
+                });
+
             modelBuilder.Entity("DotNet.Models.TattooJob", b =>
                 {
                     b.HasOne("DotNet.Models.ApplicationUser", "Creator")
@@ -713,6 +768,8 @@ namespace dotnet_server.Migrations
             modelBuilder.Entity("DotNet.Models.Consultation", b =>
                 {
                     b.Navigation("Appointments");
+
+                    b.Navigation("Messages");
                 });
 #pragma warning restore 612, 618
         }

--- a/dotnet-server/_Controllers/TenantController.cs
+++ b/dotnet-server/_Controllers/TenantController.cs
@@ -32,6 +32,7 @@ namespace DotNet.Controllers
                     t.Name,
                     t.MetaPageId,
                     t.InstagramAccountId,
+                    t.ArtistUserId,
                     t.Plan,
                     t.TrialEndsAt
                 })
@@ -46,6 +47,7 @@ namespace DotNet.Controllers
             public string? PageAccessToken { get; set; }
             public string? InstagramAccountId { get; set; }
             public string? InstagramToken { get; set; }
+            public string? ArtistUserId { get; set; }
             public string? Plan { get; set; }
             public DateTime? TrialEndsAt { get; set; }
         }
@@ -70,6 +72,7 @@ namespace DotNet.Controllers
                     Name = request.Name,
                     MetaPageId = request.MetaPageId,
                     InstagramAccountId = request.InstagramAccountId,
+                    ArtistUserId = request.ArtistUserId,
                     EncryptedPageAccessToken = _tenantService.EncryptToken(request.PageAccessToken),
                     EncryptedInstagramToken = _tenantService.EncryptToken(request.InstagramToken),
                     Plan = plan,
@@ -86,6 +89,7 @@ namespace DotNet.Controllers
                 tenant.Name = request.Name;
                 tenant.MetaPageId = request.MetaPageId;
                 tenant.InstagramAccountId = request.InstagramAccountId;
+                tenant.ArtistUserId = request.ArtistUserId;
                 tenant.EncryptedPageAccessToken = _tenantService.EncryptToken(request.PageAccessToken);
                 tenant.EncryptedInstagramToken = _tenantService.EncryptToken(request.InstagramToken);
                 if (!string.IsNullOrWhiteSpace(request.Plan))

--- a/dotnet-server/_Data/ApplicationDbContext.cs
+++ b/dotnet-server/_Data/ApplicationDbContext.cs
@@ -15,6 +15,7 @@ namespace DotNet.Data
         
         public DbSet<ArtistProfile> ArtistProfiles { get; set; }
         public DbSet<Consultation> Consultations { get; set; }
+        public DbSet<ConsultationMessage> ConsultationMessages { get; set; }
         public DbSet<TattooJob> TattooJobs { get; set; }
         public DbSet<Appointment> Appointments { get; set; }
         public DbSet<UserImage> UserImages { get; set; }
@@ -64,6 +65,16 @@ namespace DotNet.Data
                 .WithMany(u => u.ArtistConsultations)
                 .HasForeignKey(c => c.ArtistId)
                 .OnDelete(DeleteBehavior.Restrict);
+
+            builder.Entity<ConsultationMessage>()
+                .HasOne(cm => cm.Consultation)
+                .WithMany(c => c.Messages)
+                .HasForeignKey(cm => cm.ConsultationId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            builder.Entity<ConsultationMessage>()
+                .HasIndex(cm => new { cm.ConsultationId, cm.OrderIndex })
+                .IsUnique();
                 
             // TattooJob relationships
             builder.Entity<TattooJob>()

--- a/dotnet-server/_Models/ClientProfile.cs
+++ b/dotnet-server/_Models/ClientProfile.cs
@@ -16,5 +16,10 @@ namespace DotNet.Models
         public string? Email { get; set; }
 
         public string? PhoneNumber { get; set; }
+
+        /// <summary>
+        /// External messaging handle (Instagram username, FB ID, etc.).
+        /// </summary>
+        public string? ExternalHandle { get; set; }
     }
 }

--- a/dotnet-server/_Models/Consultation.cs
+++ b/dotnet-server/_Models/Consultation.cs
@@ -43,12 +43,20 @@ namespace DotNet.Models
 
         public virtual List<Appointment> Appointments { get; set; } = new List<Appointment>();
 
-        // Chat JSON
-        public string ChatHistory { get; set; } = string.Empty;
+        /// <summary>
+        /// Tracks the wizard step the assistant should ask about next.
+        /// </summary>
+        public string CurrentStep { get; set; } = "subject";
+
+        /// <summary>
+        /// Ordered chat transcript stored as individual rows instead of a JSON blob.
+        /// </summary>
+        public virtual ICollection<ConsultationMessage> Messages { get; set; } = new List<ConsultationMessage>();
 
         // Square linkage ONLY (no PII persisted)
         public string SquareCustomerId { get; set; } = string.Empty;
         public string SquareAppointmentId { get; set; } = string.Empty;
+        public string SquareSyncError { get; set; } = string.Empty;
         public string ContactFullName { get; set; } = string.Empty;
         public string ContactPhone { get; set; } = string.Empty;
 

--- a/dotnet-server/_Models/ConsultationMessage.cs
+++ b/dotnet-server/_Models/ConsultationMessage.cs
@@ -1,0 +1,33 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace DotNet.Models
+{
+    /// <summary>
+    /// Persisted chat message linked to a consultation.
+    /// </summary>
+    public class ConsultationMessage
+    {
+        [Key]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public Guid Id { get; set; }
+
+        [ForeignKey(nameof(Consultation))]
+        public Guid ConsultationId { get; set; }
+
+        public int OrderIndex { get; set; }
+
+        [Required]
+        public string Role { get; set; } = string.Empty;
+
+        [Required]
+        public string Content { get; set; } = string.Empty;
+
+        public string? ImageUrl { get; set; }
+
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+        public virtual Consultation Consultation { get; set; } = null!;
+    }
+}

--- a/dotnet-server/_Models/Tenant.cs
+++ b/dotnet-server/_Models/Tenant.cs
@@ -28,6 +28,11 @@ namespace DotNet.Models
         public string? InstagramAccountId { get; set; }
 
         /// <summary>
+        /// Default artist user that inbound messages should be routed to.
+        /// </summary>
+        public string? ArtistUserId { get; set; }
+
+        /// <summary>
         /// Encrypted long-lived Page Access Token.
         /// </summary>
         public string? EncryptedPageAccessToken { get; set; }

--- a/dotnet-server/_Services/ConsultationDto.cs
+++ b/dotnet-server/_Services/ConsultationDto.cs
@@ -26,6 +26,8 @@ namespace DotNet.Services
         public string? Size { get; set; }
         public string? PriceExpectation { get; set; }
         public string? Availability { get; set; }
+        public string? CurrentStep { get; set; }
+        public string? SquareSyncError { get; set; }
 
         // Chat history with system messages filtered out
         public List<ChatMessageDto> ChatHistory { get; set; } = new();

--- a/dotnet-server/_Services/IMessagingIntegrationService.cs
+++ b/dotnet-server/_Services/IMessagingIntegrationService.cs
@@ -1,9 +1,10 @@
 using System.Threading.Tasks;
+using DotNet.Models;
 
 namespace DotNet.Services
 {
     public interface IMessagingIntegrationService
     {
-        Task ProcessIncomingMessageAsync(string platform, string artistId, string senderHandle, string message);
+        Task<string> ProcessIncomingMessageAsync(string platform, Tenant tenant, string senderHandle, string message);
     }
 }

--- a/dotnet-server/_Services/MessagingIntegrationService.cs
+++ b/dotnet-server/_Services/MessagingIntegrationService.cs
@@ -20,18 +20,39 @@ namespace DotNet.Services
             _logger = logger;
         }
 
-        public async Task ProcessIncomingMessageAsync(string platform, string artistId, string senderHandle, string message)
+        public async Task<string> ProcessIncomingMessageAsync(string platform, Tenant tenant, string senderHandle, string message)
         {
+            if (tenant == null)
+            {
+                throw new ArgumentNullException(nameof(tenant));
+            }
+
+            if (string.IsNullOrWhiteSpace(tenant.ArtistUserId))
+            {
+                _logger.LogWarning("Tenant {TenantId} missing ArtistUserId mapping; cannot process {Platform} message from {Sender}", tenant.Id, platform, senderHandle);
+                throw new InvalidOperationException("Tenant is not linked to an artist user");
+            }
+
+            var artistId = tenant.ArtistUserId;
+
             // Lookup or create an external client based on the sender handle (phone, username, etc.)
-            var client = await _context.ClientProfiles.FirstOrDefaultAsync(c => c.PhoneNumber == senderHandle || c.Email == senderHandle);
+            var client = await _context.ClientProfiles.FirstOrDefaultAsync(c =>
+                c.ExternalHandle == senderHandle || c.PhoneNumber == senderHandle || c.Email == senderHandle);
             if (client == null)
             {
                 client = new ClientProfile
                 {
                     FullName = senderHandle,
-                    PhoneNumber = senderHandle
+                    PhoneNumber = senderHandle,
+                    ExternalHandle = senderHandle
                 };
                 _context.ClientProfiles.Add(client);
+                await _context.SaveChangesAsync();
+            }
+            else if (string.IsNullOrWhiteSpace(client.ExternalHandle))
+            {
+                client.ExternalHandle = senderHandle;
+                _context.ClientProfiles.Update(client);
                 await _context.SaveChangesAsync();
             }
 
@@ -50,8 +71,8 @@ namespace DotNet.Services
             // Send message through consultation service to generate next response
             var response = await _consultationService.SendExternalMessageAsync(consultationId, client.Id, message);
 
-            // TODO: Send 'response' back to the user via the appropriate platform API
             _logger.LogInformation("{Platform} message processed for {Sender}: {Response}", platform, senderHandle, response);
+            return response;
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace the old JSON chat transcript with a ConsultationMessages table and update the EF model plus DTOs to track the current step and Square sync errors
- overhaul ConsultationService to persist chat turns via the new table, surface Square booking results, and keep status logging consistent
- extend the messaging pipeline so tenants carry an ArtistUserId, external clients keep a handle, and Meta webhooks invoke the consultation workflow before replying through the Graph API

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ca181e9a60832297ab4c24e15be3ba