### PR TITLE
Handle optional payload when sending consultation image messages

### DIFF
--- a/dotnet-server/_Controllers/ConsultationController.cs
+++ b/dotnet-server/_Controllers/ConsultationController.cs
@@ -73,11 +73,16 @@ namespace DotNet.Controllers
         [AllowAnonymous] // ✨ allow public chat start
         public async Task<IActionResult> SendMessageWithImage(
             Guid id,
-            [FromForm] string message,
-            [FromForm] IFormFile image)
+            [FromForm] string? message,
+            [FromForm] IFormFile? image)
         {
             try
             {
+                if (string.IsNullOrWhiteSpace(message) && image == null)
+                {
+                    return BadRequest(new { error = "A message or an image must be provided." });
+                }
+
                 var userId = User?.FindFirstValue(ClaimTypes.NameIdentifier) ?? string.Empty;
                 var response = await _consultationService.SendMessageWithImageAsync(id, userId, message, image);
                 return Ok(new { response });

--- a/dotnet-server/_Services/ConsultationService.cs
+++ b/dotnet-server/_Services/ConsultationService.cs
@@ -404,8 +404,8 @@ namespace DotNet.Services
             }
         }
 
-        public async Task<string> SendMessageWithImageAsync(Guid consultationId, string userId, string message,
-            IFormFile image)
+        public async Task<string> SendMessageWithImageAsync(Guid consultationId, string userId, string? message,
+            IFormFile? image)
         {
             try
             {
@@ -426,16 +426,32 @@ namespace DotNet.Services
                 {
                     imageUrl = await _storageService.UploadFileAsync(image);
 
-                    _context.UserImages.Add(new UserImage
+                    if (!string.IsNullOrWhiteSpace(userId))
                     {
-                        UserId = userId,
-                        ImageUrl = imageUrl,
-                        ImageType = "Reference",
-                        Description = message ?? "Consultation reference image",
-                        OriginalFileName = image.FileName,
-                        FileSize = image.Length,
-                        ContentType = image.ContentType
-                    });
+                        _context.UserImages.Add(new UserImage
+                        {
+                            UserId = userId,
+                            ImageUrl = imageUrl,
+                            ImageType = "Reference",
+                            Description = message ?? "Consultation reference image",
+                            OriginalFileName = image.FileName,
+                            FileSize = image.Length,
+                            ContentType = image.ContentType
+                        });
+                    }
+                    else if (consultation.ClientId is { Length: > 0 } ownerId)
+                    {
+                        _context.UserImages.Add(new UserImage
+                        {
+                            UserId = ownerId,
+                            ImageUrl = imageUrl,
+                            ImageType = "Reference",
+                            Description = message ?? "Consultation reference image",
+                            OriginalFileName = image.FileName,
+                            FileSize = image.Length,
+                            ContentType = image.ContentType
+                        });
+                    }
 
                     consultation.ImageUrl = imageUrl;
                 }

--- a/dotnet-server/_Services/IConsultationService.cs
+++ b/dotnet-server/_Services/IConsultationService.cs
@@ -12,7 +12,7 @@ namespace DotNet.Services
         Task<Guid> StartExternalConsultationAsync(Guid clientProfileId, string artistId, string? squareArtistId);
         Task<string> SendMessageAsync(Guid consultationId, string userId, string message);
         Task<string> SendExternalMessageAsync(Guid consultationId, Guid clientProfileId, string message);
-        Task<string> SendMessageWithImageAsync(Guid consultationId, string userId, string message, IFormFile image);
+        Task<string> SendMessageWithImageAsync(Guid consultationId, string userId, string? message, IFormFile? image);
         Task<string> SendExternalMessageWithImageAsync(Guid consultationId, Guid clientProfileId, string message, IFormFile image);
         Task<ConsultationDto> GetConsultationAsync(Guid consultationId, string userId);
         Task<ConsultationDto> GetExternalConsultationAsync(Guid consultationId, Guid clientProfileId);


### PR DESCRIPTION
## Summary
- allow the consultation message-with-image endpoint to treat the text and file payloads as optional and surface a clear validation error when both are missing
- update the consultation service to cope with nullable message/image values and only persist reference images when a backing user id is available
- adjust the consultation service interface to reflect the nullable image upload signature

## Testing
- dotnet build dotnet-server/dotnet-server.csproj *(fails: `dotnet`: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb1282557c8322aad1a77a43148c6e