### PR TITLE
Improve Square submission diagnostics

### DIFF
--- a/dotnet-server/_Services/ConsultationSubmissionException.cs
+++ b/dotnet-server/_Services/ConsultationSubmissionException.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DotNet.Services;
+
+public class ConsultationSubmissionException : InvalidOperationException
+{
+    public IReadOnlyList<string> MissingFields { get; }
+
+    public ConsultationSubmissionException(IEnumerable<string> missingFields)
+        : base(BuildMessage(missingFields))
+    {
+        MissingFields = missingFields?.ToArray() ?? Array.Empty<string>();
+    }
+
+    public ConsultationSubmissionException(string message, IEnumerable<string> missingFields)
+        : base(message)
+    {
+        MissingFields = missingFields?.ToArray() ?? Array.Empty<string>();
+    }
+
+    private static string BuildMessage(IEnumerable<string> missingFields)
+    {
+        var list = missingFields?.ToArray() ?? Array.Empty<string>();
+        return list.Length == 0
+            ? "Missing required information."
+            : $"Missing required info: {string.Join(", ", list)}";
+    }
+}

--- a/dotnet-server/_Services/IConsultationService.cs
+++ b/dotnet-server/_Services/IConsultationService.cs
@@ -12,13 +12,13 @@ namespace DotNet.Services
         Task<Guid> StartExternalConsultationAsync(Guid clientProfileId, string artistId, string? squareArtistId);
         Task<string> SendMessageAsync(Guid consultationId, string userId, string message);
         Task<string> SendExternalMessageAsync(Guid consultationId, Guid clientProfileId, string message);
-        Task<string> SendMessageWithImageAsync(Guid consultationId, string userId, string message, IFormFile image);
+        Task<string> SendMessageWithImageAsync(Guid consultationId, string userId, string? message, IFormFile? image);
         Task<string> SendExternalMessageWithImageAsync(Guid consultationId, Guid clientProfileId, string message, IFormFile image);
         Task<ConsultationDto> GetConsultationAsync(Guid consultationId, string userId);
         Task<ConsultationDto> GetExternalConsultationAsync(Guid consultationId, Guid clientProfileId);
         Task<List<ConsultationDto>> GetUserConsultationsAsync(string userId);
         Task<List<ConsultationDto>> GetExternalClientConsultationsAsync(Guid clientProfileId);
         Task<bool> UpdateConsultationStatusAsync(Guid consultationId, string status, string userId);
-        Task<string> SubmitToSquareAsync(Guid consultationId, string userId);
+        Task<SquareSubmissionResult> SubmitToSquareAsync(Guid consultationId, string userId);
     }
 }

--- a/dotnet-server/_Services/ISquareAppointmentService.cs
+++ b/dotnet-server/_Services/ISquareAppointmentService.cs
@@ -1,6 +1,16 @@
+using System.Threading.Tasks;
+
+namespace DotNet.Services;
+
+public record SquareAppointmentResult(
+    string CustomerId,
+    string? AppointmentId,
+    string? FailureReason,
+    bool BookingAttempted);
+
 public interface ISquareAppointmentsService
 {
-    Task<(string customerId, string? appointmentId)> CreateAppointmentAsync(
+    Task<SquareAppointmentResult> CreateAppointmentAsync(
         string fullName,
         string phoneE164,
         string availabilityNote,

--- a/dotnet-server/_Services/SquareSubmissionResult.cs
+++ b/dotnet-server/_Services/SquareSubmissionResult.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace DotNet.Services;
+
+public record SquareSubmissionResult(
+    string? AppointmentId,
+    string? SquareCustomerId,
+    bool AppointmentCreated,
+    string Status,
+    string? SquareSyncError)
+{
+    public bool HasSquareCustomer => !string.IsNullOrWhiteSpace(SquareCustomerId);
+}


### PR DESCRIPTION
## Summary
- return structured Square submission details from the consultation controller and surface missing-field validation failures explicitly
- capture Square booking failure reasons in the consultation service and log metadata alongside the submission attempt
- have the Square appointments service emit descriptive failure reasons when configuration or API responses prevent booking creation

## Testing
- dotnet build dotnet-server/dotnet-server.csproj *(fails: `dotnet` CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb1282557c8322aad1a77a43148c6e