### PR TITLE
Enhance chat UX with greeting and loading indicator

### DIFF
--- a/angular-client/src/app/chat/chat.component.html
+++ b/angular-client/src/app/chat/chat.component.html
@@ -2,7 +2,7 @@
 	class="flex flex-col h-[calc(100vh-12rem)] bg-white dark:bg-gray-800 rounded-xl shadow-md overflow-hidden"
 >
 	<!-- Chat messages -->
-	<div class="flex-grow overflow-y-auto p-4 space-y-4" #messageContainer>
+        <div class="flex-grow overflow-y-auto p-4 space-y-4" #messageContainer>
                 <div
                         *ngFor="let msg of messages"
                         [ngClass]="
@@ -11,11 +11,44 @@
                                         : 'mr-auto bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-white'
                         "
                         class="max-w-[80%] rounded-lg p-3 shadow-sm"
+                        [class.opacity-80]="msg.pending"
                 >
                         <div class="font-medium mb-1">{{
                                 msg.sender === 'user' ? 'You' : 'AI Assistant'
                         }}</div>
-                        <div>{{ msg.text }}</div>
+                        <div class="flex items-start gap-2">
+                                <svg
+                                        *ngIf="msg.pending"
+                                        class="h-4 w-4 text-emerald-500 animate-spin mt-0.5"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        fill="none"
+                                        viewBox="0 0 24 24"
+                                >
+                                        <circle
+                                                class="opacity-25"
+                                                cx="12"
+                                                cy="12"
+                                                r="10"
+                                                stroke="currentColor"
+                                                stroke-width="4"
+                                        ></circle>
+                                        <path
+                                                class="opacity-75"
+                                                fill="currentColor"
+                                                d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+                                        ></path>
+                                </svg>
+                                <p
+                                        class="whitespace-pre-line"
+                                        [ngClass]="
+                                                msg.pending
+                                                        ? 'italic text-gray-500 dark:text-gray-200'
+                                                        : ''
+                                        "
+                                >
+                                        {{ msg.text }}
+                                </p>
+                        </div>
                         <img
                                 *ngIf="msg.imageUrl"
                                 [src]="msg.imageUrl"
@@ -79,10 +112,11 @@
                         />
                         <button
                                 (click)="sendMessage()"
-                                [disabled]="(!userInput.trim() && !selectedFile)"
+                                [disabled]="sending || (!userInput.trim() && !selectedFile)"
                                 class="bg-emerald-600 hover:bg-emerald-700 text-white px-4 py-2 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                         >
                                 <svg
+                                        *ngIf="!sending"
                                         xmlns="http://www.w3.org/2000/svg"
                                         class="h-5 w-5"
                                         viewBox="0 0 20 20"
@@ -92,7 +126,28 @@
                                                 d="M10.894 2.553a1 1 0 00-1.788 0l-7 14a1 1 0 001.169 1.409l5-1.429A1 1 0 009 15.571V11a1 1 0 112 0v4.571a1 1 0 00.725.962l5 1.428a1 1 0 001.17-1.408l-7-14z"
                                         />
                                 </svg>
+                                <svg
+                                        *ngIf="sending"
+                                        class="h-5 w-5 animate-spin"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        fill="none"
+                                        viewBox="0 0 24 24"
+                                >
+                                        <circle
+                                                class="opacity-25"
+                                                cx="12"
+                                                cy="12"
+                                                r="10"
+                                                stroke="currentColor"
+                                                stroke-width="4"
+                                        ></circle>
+                                        <path
+                                                class="opacity-75"
+                                                fill="currentColor"
+                                                d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+                                        ></path>
+                                </svg>
                         </button>
                 </div>
-	</div>
+        </div>
 </div>

--- a/angular-client/src/app/chat/chat.component.ts
+++ b/angular-client/src/app/chat/chat.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild, ElementRef } from '@angular/core'
+import { Component, OnInit, ViewChild, ElementRef, AfterViewInit } from '@angular/core'
 import { CommonModule } from '@angular/common' // for *ngFor, *ngIf, [ngClass]
 import { FormsModule } from '@angular/forms' // for [(ngModel)]
 import { firstValueFrom } from 'rxjs'
@@ -6,16 +6,21 @@ import { ChatApiService } from '../../_services/chat.service'
 import { environment } from '../../environments/environment'
 
 
-type Msg = { sender: 'user' | 'assistant'; text: string; imageUrl?: string }
+type Msg = {
+        sender: 'user' | 'assistant'
+        text: string
+        imageUrl?: string
+        pending?: boolean
+}
 
 @Component({
-	selector: 'app-chat',
-	standalone: true,
-	imports: [CommonModule, FormsModule],
-	templateUrl: './chat.component.html',
+        selector: 'app-chat',
+        standalone: true,
+        imports: [CommonModule, FormsModule],
+        templateUrl: './chat.component.html',
 })
-export class ChatComponent implements OnInit {
-	@ViewChild('messageContainer') messageContainer!: ElementRef<HTMLDivElement>
+export class ChatComponent implements OnInit, AfterViewInit {
+        @ViewChild('messageContainer') messageContainer!: ElementRef<HTMLDivElement>
 
         messages: Msg[] = []
         userInput: string = ''
@@ -23,15 +28,26 @@ export class ChatComponent implements OnInit {
         consultationId: string = ''
         selectedFile: File | null = null
         private artistId = environment.artistId
+        private readonly greeting =
+                "Hey there! I'm your AI tattoo assistant. Share your ideas or reference photos and I'll help you plan the perfect design."
 
         constructor(private chatApi: ChatApiService) {}
 
         ngOnInit() {
-                this.messages = []
+                this.messages = [
+                        {
+                                sender: 'assistant',
+                                text: this.greeting,
+                        },
+                ]
         }
 
-	// HTML calls this
-	async sendMessage() {
+        ngAfterViewInit(): void {
+                this.scrollToBottom()
+        }
+
+        // HTML calls this
+        async sendMessage() {
                 const text = (this.userInput || '').trim()
                 if ((!text && !this.selectedFile) || this.sending) return
 
@@ -42,6 +58,8 @@ export class ChatComponent implements OnInit {
                         : undefined
                 this.pushUser(text, preview)
                 this.userInput = ''
+
+                this.pushAssistant('Thinking…', true)
 
                 try {
                         if (!this.consultationId) {
@@ -77,18 +95,35 @@ export class ChatComponent implements OnInit {
 
         // Optional: hook up to a “Reset” button if you add one later
         resetConversation() {
-                this.messages = []
+                this.messages = [
+                        {
+                                sender: 'assistant',
+                                text: this.greeting,
+                        },
+                ]
+                this.consultationId = ''
         }
 
-        private pushAssistant(text: string) {
+        private pushAssistant(text: string, pending = false) {
                 if (!text) return
-                this.messages.push({ sender: 'assistant', text })
-                queueMicrotask(() => this.scrollToBottom())
+
+                if (pending) {
+                        this.messages.push({ sender: 'assistant', text, pending: true })
+                } else {
+                        const pendingIndex = this.findLastPendingAssistantIndex()
+                        if (pendingIndex !== -1) {
+                                this.messages[pendingIndex] = { sender: 'assistant', text }
+                        } else {
+                                this.messages.push({ sender: 'assistant', text })
+                        }
+                }
+
+                setTimeout(() => this.scrollToBottom())
         }
 
         private pushUser(text: string, imageUrl?: string) {
                 this.messages.push({ sender: 'user', text, imageUrl })
-                queueMicrotask(() => this.scrollToBottom())
+                setTimeout(() => this.scrollToBottom())
         }
 
         onFileSelected(event: Event) {
@@ -98,8 +133,18 @@ export class ChatComponent implements OnInit {
                 }
         }
 
-	private scrollToBottom() {
-		const el = this.messageContainer?.nativeElement
-		if (el) el.scrollTop = el.scrollHeight
-	}
+        private scrollToBottom() {
+                const el = this.messageContainer?.nativeElement
+                if (el) el.scrollTop = el.scrollHeight
+        }
+
+        private findLastPendingAssistantIndex(): number {
+                for (let i = this.messages.length - 1; i >= 0; i--) {
+                        const msg = this.messages[i]
+                        if (msg.sender === 'assistant' && msg.pending) {
+                                return i
+                        }
+                }
+                return -1
+        }
 }


### PR DESCRIPTION
## Summary
- seed the chat with a friendly assistant greeting and reuse it when resetting the conversation
- show a "Thinking…" placeholder with spinner while awaiting server replies and replace it with the final response
- ensure new messages auto-scroll into view and reflect the sending state in the submit button

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68cc4c1628c88322aed775676714c269